### PR TITLE
Conditionally render gigs page

### DIFF
--- a/src/lib/components/layout/Header.svelte
+++ b/src/lib/components/layout/Header.svelte
@@ -1,12 +1,8 @@
 <script lang="ts">
 	import HeaderLink from './HeaderLink.svelte';
-	import { artistDetails } from '../../../data/data';
+	import { artistDetails, gigs } from '../../../data/data';
 
-	let {
-		hasUpcomingGigs
-	}: {
-		hasUpcomingGigs: boolean;
-	} = $props();
+	const hasUpcomingGigs = gigs.some((gig) => new Date(gig.dateTime) > new Date());
 
 	let isStuck = $state(false);
 
@@ -33,7 +29,9 @@
 		<nav>
 			<HeaderLink href="/music" title="Music" />
 			<HeaderLink href="/lyrics" title="Lyrics" />
-			<HeaderLink href="/live" title="Live" />
+			{#if gigs.length > 0}
+				<HeaderLink href="/live" title="Live" />
+			{/if}
 			{#if artistDetails.storeUrl}
 				<HeaderLink href={artistDetails.storeUrl} title="Shop" targetBlank />
 			{/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -8,8 +8,6 @@
 	import type { Snippet } from 'svelte';
 
 	let { children }: { children?: Snippet } = $props();
-
-	const hasUpcomingGigs = gigs.some((gig) => new Date(gig.dateTime) > new Date());
 </script>
 
 <svelte:head>
@@ -22,7 +20,7 @@
 	{/if}
 </svelte:head>
 
-<Header {hasUpcomingGigs} />
+<Header />
 
 <main>
 	{@render children?.()}

--- a/src/routes/live/+page.server.ts
+++ b/src/routes/live/+page.server.ts
@@ -1,0 +1,8 @@
+import { gigs } from '../../data/data';
+
+export const load = () => {
+	if (gigs.length === 0) {
+		return null;
+	}
+	return { gigs };
+};

--- a/src/routes/live/+page.svelte
+++ b/src/routes/live/+page.svelte
@@ -1,9 +1,17 @@
 <script lang="ts">
 	import GigCard from '$lib/components/GigCard.svelte';
+	import type { GigDetails } from '$lib/interfaces/gigs';
 	import { artistDetails } from '../../data/data';
-	import { gigs } from '../../data/data';
 
-	const upcomingGigs = gigs.filter((gig) => new Date(gig.dateTime) >= new Date());
+	let { data } = $props();
+
+	const {
+		gigs
+	}: {
+		gigs: GigDetails[];
+	} = data;
+
+	const upcomingGigs = data.gigs.filter((gig: GigDetails) => new Date(gig.dateTime) >= new Date());
 	const pastGigs = gigs.filter((gig) => new Date(gig.dateTime) < new Date());
 </script>
 


### PR DESCRIPTION
It doesn't make sense to show the /live page or 'Upcoming gigs' bar if the artist doesn't perform live. With this change if the gigs data is empty then the page won't render and no link will appear in the navbar.

![image](https://github.com/user-attachments/assets/28d88258-d5a1-485b-81c8-03017fa068d6)

Keeps things clean.