### PR TITLE
Netlify Identity script and redirect on homepage

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -4,9 +4,21 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width" />
+		<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">%sveltekit.body%</div>
+		<script>
+			if (window.netlifyIdentity) {
+				window.netlifyIdentity.on('init', (user) => {
+					if (!user) {
+						window.netlifyIdentity.on('login', () => {
+							document.location.href = '/admin/';
+						});
+					}
+				});
+			}
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
Following up on #80, this adds the Netlify Identity script and a redirect to /admin on the homepage, as advised in [Decap's documentation](https://decapcms.org/docs/choosing-a-backend/). This is because Netlify Identity signup emails link to the root of the site by default and changing this requires a paid plan.

This change should make Netlify Identity emails work without having to faff around with (i.e. add /admin) the URL provided by the email.