### PR TITLE
Update README with project info and setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Skene
 
-Part of the [Gonzo Engineering](https://gonzo.engineering) project, Skene is a collection of tools and templates intended to empower musicians to create unique, independent online presences.
+Part of the [Gonzo Engineering](https://gonzo.engineering) project, Skene is a template intended to empower musicians to create unique, independent online presences.
+
+Music, gigs, and artist details input through the content management dashboard automatically generates a rich, SEO-optimised website that belongs to you. No third party platforms, no fees, just a digital home for your music life.
 
 Currently powering:
 
@@ -9,14 +11,21 @@ Currently powering:
 
 More to come, hopefully.
 
-## Why?
+### Why?
 
-Maintaining a website takes time and money, both of which most musicians would rather be spending on their music. Third party platforms offer limited control, and some subscriptions can amount to hefty sums over time.  
+Maintaining a website takes time and money, both of which musicians would rather be spending on their music. Third party platforms offer limited control and customisation, with some subscriptions amounting to hefty sums over time.
 
-The idea with Skene that if essential info - artist details, releases, lyrics, gigs, etc. - is turned into data, that data can be used to generate rich, immersive websites, giving artists fully customisable spaces of their own on the web.
+The idea with Skene is that if essential info - artist details, releases, lyrics, gigs, etc. - is turned into data, that data can be used to generate rich, immersive websites, giving artists fully customisable spaces of their own on the web.
 
 Think the [Neil Young Archives](https://neilyoungarchives.com/), but for everyone.
 
-## Auth
+## Setup
 
-Skene is (currently) set up to use Netlify Identity so artists can log in and update their information. To set this up you need to enable it in the Netlify account that's deploying the site, enable Git Gateway, and invite whatever email addresses should have access.
+Getting a Skene site up and running should take more than five minutes. That's the aspiration anyway.
+
+1. Use this template to create a new repository. You'll need a GitHub account for this
+2. Create or log into a [Netlify](https://www.netlify.com/) account and [set up deployment](https://docs.netlify.com/site-deploys/create-deploys/) for the new repository, linking a custom domain if you wish
+3. Activate [Netlify Identity](https://docs.netlify.com/security/secure-access-to-sites/identity/) in the Netlify site configuration, enable Git Gateway, and invite your email to be a user
+4. Once you've set up your user password, go to the /admin page of your site, log in, and start making it yours!
+
+With that you should have a fully fledged website costing no more than whatever you're paying for your domain name.


### PR DESCRIPTION
This adds setup steps to the README as well as a bit more about what Skene is. IN truth the setup steps probably ought to be more detailed but at the very least I'll be able to set up sites quickly for the time being.

I guess in the same spirit as the CMS it would be nice if artists could set up a Skene site more easily, but then with the right balance maybe they'd be emboldened to play with stuff like CSS themselves.